### PR TITLE
Make class public to be able to use it

### DIFF
--- a/RegExp.swift
+++ b/RegExp.swift
@@ -38,7 +38,7 @@ import Foundation
 * Swift wrapper over NSRegularExpression, aiming at giving a Ruby-like API for RegExps.
 * Inspired by http://benscheirman.com/2014/06/regex-in-swift/
 */
-class RegExp: NSObject {
+public class RegExp: NSObject {
 
     var regexp = NSRegularExpression()
 


### PR DESCRIPTION
Without this I wasn't not able to use it as a Pod unless I copy the `RegExp.swift` file into my project.
