### PR TITLE
Update to Xcode 8.0 beta 4

### DIFF
--- a/RegExp.swift
+++ b/RegExp.swift
@@ -39,20 +39,20 @@ import Foundation
 * Inspired by http://benscheirman.com/2014/06/regex-in-swift/
 */
 public class RegExp: NSObject {
+    
+    var regexp = NSRegularExpression()
 
-    var regexp = RegularExpression()
-
-    public init(pattern:String, options:RegularExpression.Options) throws {
+    public init(pattern:String, options:NSRegularExpression.Options) throws {
 
         super.init()
 
-        regexp = try RegularExpression(pattern: pattern, options: options)
+        regexp = try NSRegularExpression(pattern: pattern, options: options)
     }
 
     /// simple boolean match test
     public func isMatching(_ string:String) -> Bool {
 
-        let nbMatches = regexp.numberOfMatches(in: string, options: RegularExpression.MatchingOptions(rawValue: 0), range: fullRangeForString(string))
+        let nbMatches = regexp.numberOfMatches(in: string, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullRangeForString(string))
 
         return nbMatches > 0
     }
@@ -61,7 +61,7 @@ public class RegExp: NSObject {
     public func match(_ string:String) -> String? {
         let allStringRange = fullRangeForString(string)
 
-        if let res = regexp.firstMatch(in: string, options: RegularExpression.MatchingOptions(rawValue: 0), range: allStringRange) {
+        if let res = regexp.firstMatch(in: string, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: allStringRange) {
             let stringAsNS = string as NSString
             let firstMatch = stringAsNS.substring(with: res.range)
             return firstMatch
@@ -77,13 +77,13 @@ public class RegExp: NSObject {
 
         let stringAsNS = string as NSString
 
-        regexp.enumerateMatches(in: string, options: RegularExpression.MatchingOptions(rawValue: 0), range: fullRangeForString(string)) {
-            (textCheckingResult:TextCheckingResult?, flags:RegularExpression.MatchingFlags, stop:UnsafeMutablePointer<ObjCBool>) -> Void in
+        regexp.enumerateMatches(in: string, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: fullRangeForString(string)) {
+            (textCheckingResult:NSTextCheckingResult?, flags: NSRegularExpression.MatchingFlags, stop:UnsafeMutablePointer<ObjCBool>) -> Void in
 
             if let textCheckingResult = textCheckingResult {
                 for i in 0..<textCheckingResult.numberOfRanges {
 
-                    let subMatch = stringAsNS.substring(with: textCheckingResult.range(at: i))
+                    let subMatch = stringAsNS.substring(with: textCheckingResult.rangeAt(i))
                     matches.append(subMatch as String)
                 }
             }

--- a/SwiftRegExpTests/RegExpTest.swift
+++ b/SwiftRegExpTests/RegExpTest.swift
@@ -24,7 +24,7 @@ class RegExpTest: XCTestCase {
 
     func testIsMatching() {
         do {
-            let regexp = try RegExp(pattern:"abc", options:RegularExpression.Options.caseInsensitive)
+            let regexp = try RegExp(pattern:"abc", options: NSRegularExpression.Options.caseInsensitive)
 
             let isMatching = regexp.isMatching("foo abc bar")
 
@@ -38,7 +38,7 @@ class RegExpTest: XCTestCase {
     func testCreationFail() {
 
         do {
-            let _ = try RegExp(pattern:"abc(", options:RegularExpression.Options.caseInsensitive) // should throw
+            let _ = try RegExp(pattern:"abc(", options: NSRegularExpression.Options.caseInsensitive) // should throw
 
             XCTFail("RegExp creation test init fail")
 
@@ -50,7 +50,7 @@ class RegExpTest: XCTestCase {
 
     func testMatches() {
         do {
-            let regexp = try RegExp(pattern:"abc(.*)def(.*)", options:RegularExpression.Options.caseInsensitive)
+            let regexp = try RegExp(pattern:"abc(.*)def(.*)", options: NSRegularExpression.Options.caseInsensitive)
 
             let string = "abcXXXdefYYY"
             let matches = regexp.allMatches(string)
@@ -66,7 +66,7 @@ class RegExpTest: XCTestCase {
 
     func testMatch() {
         do {
-            let regexp = try RegExp(pattern:"ab.", options:RegularExpression.Options.caseInsensitive)
+            let regexp = try RegExp(pattern:"ab.", options: NSRegularExpression.Options.caseInsensitive)
 
             let match = regexp.match("abcdef")
 
@@ -80,7 +80,7 @@ class RegExpTest: XCTestCase {
     func testOperator1() {
 
         do {
-            let regexp = try RegExp(pattern:"ab.", options:RegularExpression.Options.caseInsensitive)
+            let regexp = try RegExp(pattern:"ab.", options: NSRegularExpression.Options.caseInsensitive)
 
             let match = regexp =~ "abcdef"
 
@@ -95,7 +95,7 @@ class RegExpTest: XCTestCase {
     func testOperator2() {
 
         do {
-            let regexp = try RegExp(pattern:"ab.", options:RegularExpression.Options.caseInsensitive)
+            let regexp = try RegExp(pattern:"ab.", options: NSRegularExpression.Options.caseInsensitive)
 
             let match = "abcdef" =~ regexp
 


### PR DESCRIPTION
@glaurent Updated for Xcode 8.0 beta 4. For some reason `RegularExpression` was reverted back to `NSRegularExpression` in beta 4. Let me know if you have any question.
